### PR TITLE
add missing close parens in template sql (Annex M)

### DIFF
--- a/spec/annexes/extension_geometry_type_triggers.adoc
+++ b/spec/annexes/extension_geometry_type_triggers.adoc
@@ -53,7 +53,7 @@ BEGIN
   WHERE (SELECT geometry_type_name FROM gpkg_geometry_columns
          WHERE Lower(table_name) = Lower('<t>')
 	         AND Lower(column_name) = Lower('<c>')
-	         AND gpkg_IsAssignable(geometry_type_name, ST_GeometryType(NEW.<c>)) = 0;
+	         AND gpkg_IsAssignable(geometry_type_name, ST_GeometryType(NEW.<c>)) = 0);
 END
 
 CREATE TRIGGER fgtu_<t>_<c> BEFORE UPDATE OF '<c>' ON '<t>' FOR EACH ROW
@@ -62,7 +62,7 @@ BEGIN
   WHERE (SELECT geometry_type_name FROM gpkg_geometry_columns
          WHERE Lower(table_name) = Lower('<t>')
 	         AND Lower(column_name) = Lower('<c>')
-	         AND gpkg_IsAssignable(geometry_type_name, ST_GeometryType(NEW.<c>)) = 0;
+	         AND gpkg_IsAssignable(geometry_type_name, ST_GeometryType(NEW.<c>)) = 0);
 END
 ----
 


### PR DESCRIPTION
See [libspatialite](https://www.gaia-gis.it/fossil/libspatialite/index) (src/geopackage/gpkg_add_geometry_triggers.c) as of v4.3.0 for an example of an implementer who has added the missing close-parens.

Came across this in the course of implementing Annex M for a closed source project.