### PR TITLE
Make extension out-reference document more general.

### DIFF
--- a/spec/2e_extensions-mechanism.adoc
+++ b/spec/2e_extensions-mechanism.adoc
@@ -56,7 +56,7 @@ The `column_name` column value in a `gpkg_extensions` row SHALL be the name of a
 Each `extension_name` column value in a `gpkg_extensions` row SHALL be a unique case sensitive value of the form <author>_<extension_name> where <author> indicates the person or organization that developed and
 maintains the extension. The valid character set for <author> SHALL be [a-zA-Z0-9].
 The valid character set for <extension_name> SHALL be [a-zA-Z0-9_].
-An `extension_name` for the “gpkg” author name SHALL be one of those defined in this encoding standard or in an OGC Best Practices Document that extends it.
+An `extension_name` for the “gpkg” author name SHALL be one of those defined in this encoding standard or in an OGC document (e.g. Best Practices Document or Encoding Standard) that extends it.
 
 Complete examples of how to fill out the GeoPackage Extension Template in <<extension_template>> are provided by Annex F.
 The definition column value in a `gpkg_extensions` row for those extensions SHALL contain the sub-annex name and as a reference (e.g., F.3 RTree Spatial Indexes).


### PR DESCRIPTION
As written, there are only two cases - the GeoPackage specification, or a Best Practices document. That would exclude something like the Elevation Extension (written as a spec, not a best practices). So make it a bit more general and provide some examples.