### PR TITLE
Update Req2 Foot1 with correct decimal and hexadecimal values for GP11

### DIFF
--- a/spec/1_base.adoc
+++ b/spec/1_base.adoc
@@ -26,7 +26,7 @@ Using SQLite as the basis for GeoPackage simplifies production, distribution and
 
 :req1_foot1: footnote:[SQLite version 4 (reference B25), which will be an alternative to version 3, not a replacement thereof, was not available when this standard was written. See Future Work clause in Annex B.]
 :req1_foot2: footnote:[SQLite is in the public domain (see http://www.sqlite.org/copyright.html)]
-:req2_foot1: footnote:[With SQLite versions 3.7.17 and later this value MAY be set with the "PRAGMA application_id=1196437808;" SQL statement, where 1196437808 is the 32-bit integer value of 0x47503130. With earlier versions of SQLite the application id can be set by writing the byte sequence 0x47, 0x50, 0x31, 0x30 at offset 68 in the SQLite database file (see http://www.sqlite.org/fileformat2.html#database_header for details).]
+:req2_foot1: footnote:[With SQLite versions 3.7.17 and later this value MAY be set with the "PRAGMA application_id=1196437809;" SQL statement, where 1196437809 is the 32-bit integer value of 0x47503131. With earlier versions of SQLite the application id can be set by writing the byte sequence 0x47, 0x50, 0x31, 0x31 at offset 68 in the SQLite database file (see http://www.sqlite.org/fileformat2.html#database_header for details).]
 
 [requirement]
 A GeoPackage SHALL be a http://www.sqlite.org/[SQLite] <<5>> database file using http://sqlite.org/fileformat2.html[version 3 of the SQLite file format] <<6>> <<7>>.


### PR DESCRIPTION
Due to the version bump done in https://github.com/opengeospatial/geopackage/issues/188