### PR TITLE
Fix header length specification.

### DIFF
--- a/spec/1_base.adoc
+++ b/spec/1_base.adoc
@@ -30,7 +30,7 @@ Using SQLite as the basis for GeoPackage simplifies production, distribution and
 
 [requirement]
 A GeoPackage SHALL be a http://www.sqlite.org/[SQLite] <<5>> database file using http://sqlite.org/fileformat2.html[version 3 of the SQLite file format] <<6>> <<7>>.
-The first 16 bytes of a GeoPackage SHALL contain “SQLite format 3” {req1_foot1} in ASCII <<B4>>. {req1_foot2}
+The first 15 bytes of a GeoPackage SHALL contain “SQLite format 3” {req1_foot1} in ASCII <<B4>>. {req1_foot2}
 
 [requirement]
 A GeoPackage SHALL contain 0x47503131 ("GP11" in ASCII) in the application id field of the SQLite database header to indicate a GeoPackage version 1.1 file. {req2_foot1}


### PR DESCRIPTION
If you want it to be 16 bytes to match the way sqlite does it, you
need to figure out how to express the embedded NULL (C escape \0)
in spec-compliant way.