### PR TITLE
Removing SRS matching requirement between Contents and Tile Matrix Set or Geometry Columns

### DIFF
--- a/spec/1_base.adoc
+++ b/spec/1_base.adoc
@@ -187,7 +187,7 @@ A GeoPackage file SHALL include a `gpkg_contents` table per table <<gpkg_content
 |`min_y` |DOUBLE |Bounding box minimum northing or latitude for all content in table_name |yes | |
 |`max_x` |DOUBLE |Bounding box maximum easting or longitude for all content in table_name |yes | |
 |`max_y` |DOUBLE |Bounding box maximum northing or latitude for all content in table_name |yes | |
-|`srs_id` |INTEGER |Spatial Reference System ID: `gpkg_spatial_ref_sys.srs_id`; when `data_type` is features, SHALL also match `gpkg_geometry_columns.srs_id`; When data_type is tiles, SHALL also match `gpkg_tile_matrix_set.srs_id` |yes | |FK
+|`srs_id` |INTEGER |Spatial Reference System ID: `gpkg_spatial_ref_sys.srs_id` |yes | |FK
 |=======================================================================
 
 See <<gpkg_contents_sql>>.


### PR DESCRIPTION
Removing SRS Id matching requirement between Contents, Geometry Columns, and Tile Matrix Set from Contents Table srs_id column description.