### PR TITLE
more clarity on bounds for tiles

### DIFF
--- a/spec/1_base.adoc
+++ b/spec/1_base.adoc
@@ -224,10 +224,10 @@ A GeoPackage file SHALL include a `gpkg_contents` table per table <<gpkg_content
 |`identifier` |TEXT |A human-readable identifier (e.g. short name) for the table_name content |yes | |UNIQUE
 |`description` |TEXT |A human-readable description for the table_name content |yes |'' |
 |`last_change` |DATETIME |timestamp of last change to content, in ISO 8601 format|no |`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')` |
-|`min_x` |DOUBLE |Bounding box minimum easting or longitude for all content in table_name |yes | |
-|`min_y` |DOUBLE |Bounding box minimum northing or latitude for all content in table_name |yes | |
-|`max_x` |DOUBLE |Bounding box maximum easting or longitude for all content in table_name |yes | |
-|`max_y` |DOUBLE |Bounding box maximum northing or latitude for all content in table_name |yes | |
+|`min_x` |DOUBLE |Bounding box minimum easting or longitude for all content in table_name. If tiles, this is informational and the tile matrix set should be used for calculating tile coordinates. |yes | |
+|`min_y` |DOUBLE |Bounding box minimum northing or latitude for all content in table_name. If tiles, this is informational and the tile matrix set should be used for calculating tile coordinates. |yes | |
+|`max_x` |DOUBLE |Bounding box maximum easting or longitude for all content in table_name. If tiles, this is informational and the tile matrix set should be used for calculating tile coordinates.|yes | |
+|`max_y` |DOUBLE |Bounding box maximum northing or latitude for all content in table_name. If tiles, this is informational and the tile matrix set should be used for calculating tile coordinates.|yes | |
 |`srs_id` |INTEGER |Spatial Reference System ID: `gpkg_spatial_ref_sys.srs_id`; when `data_type` is features, SHALL also match `gpkg_geometry_columns.srs_id`; When data_type is tiles, SHALL also match `gpkg_tile_matrix_set.srs_id` |yes | |FK
 |=======================================================================
 


### PR DESCRIPTION
reading the spec, a developer would likely take these mins and maxes literally from the spec, which seems to contradict the "Getting Started" guidelines: http://www.geopackage.org/guidance/getting-started.html#gpkg_contents

Syncing up this verbage for the guideline with the spec would clear up confusion.