### PR TITLE
Data Columns for Attributes Tables

### DIFF
--- a/spec/annexes/extension_schema.adoc
+++ b/spec/annexes/extension_schema.adoc
@@ -55,7 +55,7 @@ If present it SHALL be defined per <<gpkg_data_columns_cols>> and <<gpkg_data_co
 [cols=",,,,",options="header",]
 |=======================================================================
 |Column Name |Column Type |Column Description |Null |Key
-|`table_name` |TEXT |Name of the tiles or feature table |no |PK
+|`table_name` |TEXT |Name of a table specified by reference to `gpkg_contents.table_name` |no |PK
 |`column_name` |TEXT |Name of the table column |no |PK
 |`name` |TEXT |A human-readable identifier (e.g. short name) for the column_name content |yes |UNIQUE
 |`title` |TEXT |A human-readable formal title for the column_name content |yes |


### PR DESCRIPTION
This pull request updates the description of the table_name column in the gpkg_data_columns to be more in line with Requirement 104.

The description for the column table_name in Table 23 states: 'Name of the tiles or feature table', however the description of Requirement 104 states: 'Values of the gpkg_data_columns table table_name column value SHALL reference values in the gpkg_contents table_name column.'. This leads me to believe that any type of table that is in the gpkg_contents table should be allowed in the table_name of the gpkg_data_columns table, including Attributes tables.

The description for the table_name column in Table 23 should be updated to be in line with Requirement 104.