### PR TITLE
Fix wrong definition of trigger gpkg_metadata_reference_column_name_u…

### DIFF
--- a/spec/annexes/extension_metadata.adoc
+++ b/spec/annexes/extension_metadata.adoc
@@ -576,7 +576,7 @@ SELECT RAISE(ABORT, 'update on table gpkg_metadata_reference
 violates constraint: column name must be NULL when reference_scope
 is "geopackage", "table" or "row"')
 WHERE (NEW.reference_scope IN ('geopackage','table','row')
-AND NEW.column_nameIS NOT NULL);
+AND NEW.column_name IS NOT NULL);
 SELECT RAISE(ABORT, 'update on table gpkg_metadata_reference
 violates constraint: column name must be defined for the specified
 table when reference_scope is "column" or "row/col"')


### PR DESCRIPTION
…pdate

There is a missing space between column_name and IS in the 'NEW.column_nameIS NOT NULL' fragment. In addition to being invalid, with the next SQLite version (3.25.1 likely), "ALTER TABLE foo RENAME TO bar" statements will also fail because of this invalid trigger.

Note: there's currently a bug in 3.25.0 that causes such rename statements to fail on a GeoPackage vector layer with a RTree (see https://www.sqlite.org/src/info/05a9d129254e01a5)