### PR TITLE
ATS version check supporting text to be 1.x

### DIFF
--- a/spec/annexes/ats.adoc
+++ b/spec/annexes/ats.adoc
@@ -24,7 +24,7 @@
 [cols="1,5a"]
 |========================================
 |*Test Case ID* |++/base/core/container/data/file_format/application_id++
-|*Test Purpose* |Verify that the SQLite database header application id field indicates GeoPackage version 1.0
+|*Test Purpose* |Verify that the SQLite database header application id field indicates GeoPackage version 1.x
 |*Test Method* 
 | . Retrieve the bytes at the application id of the SQLite database header 
 . If the string is "GP10" in ASCII, fall back to the tests for GeoPackage 1.0.


### PR DESCRIPTION
The test covers 1.0, 1.1 and the 1.2+ versions.

Resolves #471 