### PR TITLE
Extension: fix typo in text regarding "write-only"

### DIFF
--- a/spec/2e_extensions-mechanism.adoc
+++ b/spec/2e_extensions-mechanism.adoc
@@ -106,5 +106,5 @@ The scope column value in a `gpkg_extensions` row SHALL be lowercase "read-write
 Some extensions do not impose any additional requirements on software that accesses a GeoPackage in a read-only fashion.
 An example of this is an extension that defines an SQL trigger that uses a non-standard SQL function defined in a GeoPackage SQLite Extension.
 Triggers are only invoked when data is written to the GeoPackage, so usage of this type of extension can be safely ignored for read-only access.
-This is indicated by a gpkg_extensions.scope column value of "write_only".
+This is indicated by a gpkg_extensions.scope column value of "write-only".
 


### PR DESCRIPTION
The "write_only" value (with underscore) was used, whereas "write-only" (with dash) is used every where else.