### PR TITLE
Use uniqueness keys consistently in "table" tables

### DIFF
--- a/spec/1_base.adoc
+++ b/spec/1_base.adoc
@@ -231,7 +231,7 @@ A GeoPackage file SHALL include a `gpkg_contents` table per table <<gpkg_content
 |Column Name |Type |Description |Null |Default |Key
 |`table_name` |TEXT |The name of the actual content (e.g., tiles, features, or attributes) table |no | |PK
 |`data_type` |TEXT |Type of data stored in the table |no | |
-|`identifier` |TEXT |A human-readable identifier (e.g. short name) for the table_name content |yes | |UNIQUE
+|`identifier` |TEXT |A human-readable identifier (e.g. short name) for the table_name content |yes | |UK
 |`description` |TEXT |A human-readable description for the table_name content |yes |'' |
 |`last_change` |DATETIME |timestamp of last change to content, in ISO 8601 format|no |`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')` |
 |`min_x` |DOUBLE |Bounding box minimum easting or longitude for all content in table_name. If tiles, this is informational and the tile matrix set should be used for calculating tile coordinates. |yes | |

--- a/spec/annexes/background.adoc
+++ b/spec/annexes/background.adoc
@@ -109,6 +109,8 @@ SRID::
         Spatial Reference (System) Identifier
 UML::
        Unified Modeling Language
+UK::
+       Unique Key
 UTC::
        Coordinated Universal Time
 XML::

--- a/spec/annexes/extension_schema.adoc
+++ b/spec/annexes/extension_schema.adoc
@@ -55,9 +55,9 @@ If present it SHALL be defined per <<gpkg_data_columns_cols>> and <<gpkg_data_co
 [cols=",,,,",options="header",]
 |=======================================================================
 |Column Name |Column Type |Column Description |Null |Key
-|`table_name` |TEXT |Name of a table specified in `gpkg_contents.table_name` or `gpkg_extensions.table_name` |no |PK
+|`table_name` |TEXT |Name of a table specified in `gpkg_contents.table_name` or `gpkg_extensions.table_name` |no |PK, UK
 |`column_name` |TEXT |Name of the table column |no |PK
-|`name` |TEXT |A human-readable identifier (e.g. short name) for the column_name content |yes |UNIQUE
+|`name` |TEXT |A human-readable identifier (e.g. short name) for the column_name content |yes |UK
 |`title` |TEXT |A human-readable formal title for the column_name content |yes |
 |`description` |TEXT |A human-readable description for the column_name content |yes |
 |`mime_type` |TEXT |http://www.iana.org/assignments/media-types/index.html[MIME] <<21>> type of column_name if BLOB type, or NULL for other types |yes |

--- a/spec/annexes/extension_schema.adoc
+++ b/spec/annexes/extension_schema.adoc
@@ -95,9 +95,9 @@ The `constraint_name` column is referenced by the `constraint_name` column in th
 [cols=",,,,",options="header",]
 |=======================================================================
 |Column Name |Column Type |Column Description |Null |Key
-|`constraint_name` |TEXT |Name of constraint (lowercase)|no |Unique
-|`constraint_type` |TEXT |Type name of constraint: 'range' \| 'enum' \| 'glob' |no |Unique
-|`value` |TEXT |Specified case sensitive value for 'enum' or 'glob' or NULL for 'range' constraint_type |yes |Unique
+|`constraint_name` |TEXT |Name of constraint (lowercase)|no |Jointly Unique
+|`constraint_type` |TEXT |Type name of constraint: 'range' \| 'enum' \| 'glob' |no |Jointly Unique
+|`value` |TEXT |Specified case sensitive value for 'enum' or 'glob' or NULL for 'range' constraint_type |yes |Jointly Unique
 |`min` |NUMERIC |Minimum value for 'range' or NULL for 'enum' or 'glob' constraint_type |yes |
 |`min_is_inclusive` |BOOLEAN |0 (false) if min value is exclusive, or 1 (true) if min value is inclusive |yes |
 |`max` |NUMERIC |Maximum value for 'range' or NULL for 'enum' or 'glob' constraint_type |yes |


### PR DESCRIPTION
This swallows #497.
This eliminates a key value of "unique" in favor of "UK" or "Jointly Unique".