### PR TITLE
clarifying metadata extension

### DIFF
--- a/spec/annexes/extension_metadata.adoc
+++ b/spec/annexes/extension_metadata.adoc
@@ -60,7 +60,7 @@ The GeoPackage interpretation of what constitutes "metadata" is a broad one that
 [cols=",,,,,",options="header",]
 |=======================================================================
 |Column Name |Column Type |Column Description |Null |Default |Key
-|`id` |INTEGER |Metadata primary key |no | |PK
+|`id` |INTEGER |Autoincrement primary key |no | |PK
 |`md_scope` |TEXT |Case sensitive name of the data scope to which this metadata applies; see <<metadata_scopes>> below |no |'dataset' |
 |`md_standard_uri` |TEXT |URI <<23>> reference to the metadata structure definition authority ^<<K29>>^ |no | any |
 |`mime_type` |TEXT |MIME <<21>> encoding of metadata |no |'text/xml' <<24>> |
@@ -176,7 +176,13 @@ The initial contents of this table were obtained from the ISO 19115 <<28>>, Anne
 [caption=""]
 .Requirement 94
 ====
-Each `md_scope` column value in a `gpkg_metadata` table SHALL be one of the name column values from <<metadata_scopes>>.
+[line-through]#Each `md_scope` column value in a `gpkg_metadata` table SHALL be one of the name column values from <<metadata_scopes>>.#
+====
+
+[WARNING]
+====
+Each `md_scope` column value in a `gpkg_metadata` table SHOULD be one of the name column values from <<metadata_scopes>>.
+However, this list is not exhaustive; new scopes are permitted.
 ====
 
 [float]


### PR DESCRIPTION
closes #512

* [x] The primary key in `gpkg_metadata` should be marked as "autoincrement" like other integer primary keys. I believe this was always the intent (and the SQL is right) but it wasn't written that way in the [table](http://www.geopackage.org/spec/#gpkg_metadata_cols).
* [x] The set of metadata scopes should be open, not closed. Existing scopes should be used when possible, but it should be possible to add additional metadata scopes when the existing ones don't apply. This eliminates [requirement 94](http://www.geopackage.org/spec/#r94) and replaces it with a warning.