### PR TITLE
gpkg_metadata table definition SQL

### DIFF
--- a/spec/annexes/extension_metadata.adoc
+++ b/spec/annexes/extension_metadata.adoc
@@ -444,7 +444,7 @@ Every `gpkg_metadata_reference` table row `md_parent_id` column value that is NO
 [source,sql]
 ----
 CREATE TABLE gpkg_metadata (
-  id INTEGER CONSTRAINT m_pk PRIMARY KEY ASC NOT NULL,
+  id INTEGER CONSTRAINT m_pk PRIMARY KEY AUTOINCREMENT NOT NULL,
   md_scope TEXT NOT NULL DEFAULT 'dataset',
   md_standard_uri TEXT NOT NULL,
   mime_type TEXT NOT NULL DEFAULT 'text/xml',

--- a/spec/annexes/metadataexample.adoc
+++ b/spec/annexes/metadataexample.adoc
@@ -7,7 +7,7 @@ Suppose we have this metadata:
 [source,sql]
 ----
 CREATE TABLE gpkg_metadata (
-  id INTEGER CONSTRAINT m_pk PRIMARY KEY ASC NOT NULL,
+  id INTEGER CONSTRAINT m_pk PRIMARY KEY AUTOINCREMENT NOT NULL,
   md_scope TEXT NOT NULL DEFAULT 'dataset',
   md_standard_uri TEXT NOT NULL,
   mime_type TEXT NOT NULL DEFAULT 'text/xml',


### PR DESCRIPTION
#512 and #513 add Autoincrement to the Metadata Table Definition id column. Should the gpkg_metadata table definition therefore be consistent with other GeoPackage auto incrementing integer primary keys?  Features, Tiles, and Attributes all specify AUTOINCREMENT in the table definition for their integer primary keys.  Specifying AUTOINCREMENT prevents the reuse of ROWIDs in a table over the lifetime of the database (vs max ROWID + 1).  Additionally, ROWIDs are stored as keys in the B-tree, so I'm not sure the ascending order (ASC) is worth having.