### PR TITLE
Removing superfluous primary key clauses like autoincrement

### DIFF
--- a/spec/2a_features.adoc
+++ b/spec/2a_features.adoc
@@ -317,7 +317,7 @@ Using an integer primary key in a feature table allows features to be linked to 
 [cols=",,,,,",options="header"]
 |=======================================================================
 |Column Name |Type |Description |Null |Default |Key
-|`id` |INTEGER |Autoincrement primary key |no | |PK
+|`id` |INTEGER |Primary key |no | |PK
 |`geometry` |GEOMETRY |GeoPackage Geometry |yes | |
 |`text_attribute` |TEXT |Text attribute of feature |yes | |
 |`real_attribute` |REAL |Real attribute of feature |yes | |

--- a/spec/2b_tiles.adoc
+++ b/spec/2b_tiles.adoc
@@ -301,7 +301,7 @@ For a tiles table, the `id` column SHOULD be a primary key to ensure that each v
 [cols=",,,,,",options="header",]
 |=======================================================================
 |Column Name |Column Type |Column Description |Null |Default |Key
-|`id` |INTEGER |Autoincrement primary key |no | |PK
+|`id` |INTEGER |Primary key |no | |PK
 |`zoom_level` |INTEGER |min(zoom_level) \<= `zoom_level` \<= max(zoom_level) for `t_table_name` |no | |UK
 |`tile_column` |INTEGER |0 to `tile_matrix` `matrix_width` – 1 |no | |UK
 |`tile_row` |INTEGER |0 to `tile_matrix` `matrix_height` - 1 |no | |UK

--- a/spec/2f_attributes.adoc
+++ b/spec/2f_attributes.adoc
@@ -58,7 +58,7 @@ Using an integer primary key in an attributes table allows attributes to be link
 [cols=",,,,",options="header",]
 |=======================================================================
 |Column Name |Col Type |Column Description |Null |Key
-|`id` |INTEGER |Autoincrement primary key |no |PK
+|`id` |INTEGER |Primary key |no |PK
 |`text_attribute` |TEXT |Text attribute of feature |yes |
 |`real_attribute` |REAL |Real attribute of feature |yes | 
 |`boolean_attribute` |BOOLEAN |Boolean attribute of feature |yes |

--- a/spec/annexes/ddl.adoc
+++ b/spec/annexes/ddl.adoc
@@ -2,6 +2,13 @@
 [appendix]
 == Table Definition SQL (Normative)
 
+[NOTE]
+====
+A GeoPackage MAY have minor changes to the table definition SQL
+such as declaring a primary key AUTOINCREMENT as long as the identifier names,
+data types, null declarations, primary keys, and key constraints are kept intact.
+====
+
 === gpkg_spatial_ref_sys
 
 [[gpkg_spatial_ref_sys_sql]]
@@ -132,7 +139,7 @@ NOTE: Implementer must provide code4name(geometry_type_name) SQL function
 [source,sql]
 ----
 CREATE TABLE sample_feature_table (
-  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  id INTEGER PRIMARY KEY,
   geometry GEOMETRY,
   text_attribute TEXT,
   real_attribute REAL,
@@ -205,7 +212,7 @@ INSERT INTO gpkg_tile_matrix VALUES (
 [source,sql]
 ----
 CREATE TABLE sample_tile_pyramid (
-  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  id INTEGER PRIMARY KEY,
   zoom_level INTEGER NOT NULL,
   tile_column INTEGER NOT NULL,
   tile_row INTEGER NOT NULL,
@@ -254,7 +261,7 @@ CREATE TABLE gpkg_extensions (
 [source,sql]
 ----
 CREATE TABLE sample_attributes (
-  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  id INTEGER PRIMARY KEY,
   text_attribute TEXT,
   real_attribute REAL,
   boolean_attribute BOOLEAN,

--- a/spec/annexes/extension_metadata.adoc
+++ b/spec/annexes/extension_metadata.adoc
@@ -60,7 +60,7 @@ The GeoPackage interpretation of what constitutes "metadata" is a broad one that
 [cols=",,,,,",options="header",]
 |=======================================================================
 |Column Name |Column Type |Column Description |Null |Default |Key
-|`id` |INTEGER |Autoincrement primary key |no | |PK
+|`id` |INTEGER |Primary key |no | |PK
 |`md_scope` |TEXT |Case sensitive name of the data scope to which this metadata applies; see <<metadata_scopes>> below |no |'dataset' |
 |`md_standard_uri` |TEXT |URI <<23>> reference to the metadata structure definition authority ^<<K29>>^ |no | any |
 |`mime_type` |TEXT |MIME <<21>> encoding of metadata |no |'text/xml' <<24>> |
@@ -444,7 +444,7 @@ Every `gpkg_metadata_reference` table row `md_parent_id` column value that is NO
 [source,sql]
 ----
 CREATE TABLE gpkg_metadata (
-  id INTEGER CONSTRAINT m_pk PRIMARY KEY ASC NOT NULL,
+  id INTEGER PRIMARY KEY,
   md_scope TEXT NOT NULL DEFAULT 'dataset',
   md_standard_uri TEXT NOT NULL,
   mime_type TEXT NOT NULL DEFAULT 'text/xml',

--- a/spec/annexes/metadataexample.adoc
+++ b/spec/annexes/metadataexample.adoc
@@ -4,17 +4,6 @@
 
 Suppose we have this metadata:
 
-[source,sql]
-----
-CREATE TABLE gpkg_metadata (
-  id INTEGER CONSTRAINT m_pk PRIMARY KEY ASC NOT NULL,
-  md_scope TEXT NOT NULL DEFAULT 'dataset',
-  md_standard_uri TEXT NOT NULL,
-  mime_type TEXT NOT NULL DEFAULT 'text/xml',
-  metadata TEXT NOT NULL DEFAULT ''
-)
-----
-
 [cols=",,,",options="header"]
 |======
 |id |md_scope |md_standard_uri |metadata
@@ -26,23 +15,6 @@ CREATE TABLE gpkg_metadata (
 |7 |attributeType |http://www.isotc211.org/2005/gmd |TEXT
 |8 |attribute |http://www.isotc211.org/2005/gmd |TEXT
 |======
-
-and this reference table definition:
-
-[source,sql]
-----
-CREATE TABLE gpkg_metadata_reference (
-  reference_scope TEXT NOT NULL,
-  table_name TEXT,
-  column_name TEXT,
-  row_id_value INTEGER,
-  timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  md_file_id INTEGER NOT NULL,
-  md_parent_id INTEGER,
-  CONSTRAINT crmr_mfi_fk FOREIGN KEY (md_file_id) REFERENCES gpkg_metadata(id),
-  CONSTRAINT crmr_mpi_fk FOREIGN KEY (md_parent_id) REFERENCES gpkg_metadata(id)
-)
-----
 
 1) Consider a geographic data provider generating vector mapping data for three Administrative areas(A, B and C).  ... The metadata could be carried exclusively at Dataset Series level.
 


### PR DESCRIPTION
closes #517 