### PR TITLE
Update description of table_name and data_type

### DIFF
--- a/spec/1_base.adoc
+++ b/spec/1_base.adoc
@@ -243,8 +243,8 @@ A GeoPackage file SHALL include a `gpkg_contents` table per table <<gpkg_content
 [cols=",,,,,",options="header",]
 |=======================================================================
 |Column Name |Type |Description |Null |Default |Key
-|`table_name` |TEXT |The name of the actual content (e.g., tiles, features, or attributes) table |no | |PK
-|`data_type` |TEXT |Type of data stored in the table |no | |
+|`table_name` |TEXT |The name of the actual content (e.g., tiles, features, or attributes) table or view |no | |PK
+|`data_type` |TEXT |Type of data stored in the table or view |no | |
 |`identifier` |TEXT |A human-readable identifier (e.g. short name) for the table_name content |yes | |UK
 |`description` |TEXT |A human-readable description for the table_name content |yes |'' |
 |`last_change` |DATETIME |timestamp of last change to content, in ISO 8601 format|no |`strftime('%Y-%m-%dT%H:%M:%fZ', 'now')` |


### PR DESCRIPTION
In the INSPIRE community, there was a question on whether views should be added to `gpkg_contents`, see also https://github.com/INSPIRE-MIF/gp-geopackage-encodings/issues/10#issuecomment-762802513 I was wondering if that should be made a bit more explicit in the specification, therefore this proposal to update the description of `table_name` and `data_type` to state "table or view" instead of "table".