### PR TITLE
Fixe typo in extension_metadata.adoc

### DIFF
--- a/spec/core/annexes/extension_metadata.adoc
+++ b/spec/core/annexes/extension_metadata.adoc
@@ -49,7 +49,7 @@ Read-write
 [caption=""]
 .Requirement 93
 ====
-A GeoPackage A GeoPackage MAY contain a table named `gpkg_metadata`. If present it SHALL be defined per clauses <<metadata_table_table_definition>>, <<gpkg_metadata_cols>>, and <<gpkg_metadata_sql>>.
+A GeoPackage MAY contain a table named `gpkg_metadata`. If present it SHALL be defined per clauses <<metadata_table_table_definition>>, <<gpkg_metadata_cols>>, and <<gpkg_metadata_sql>>.
 ====
 
 The first component of GeoPackage metadata is the `gpkg_metadata` table that MAY contain metadata in MIME <<I21>> encodings structured in accordance with any authoritative metadata specification, such as ISO 19115 <<I28>>, ISO 19115-2 <<B6>>, ISO 19139 <<B7>>, Dublin Core <<B8>>, CSDGM <<B10>>, DDMS <<B12>>, NMF/NMIS <<B13>>, etc.


### PR DESCRIPTION
Errata: "A GeoPackage A GeoPackage MAY contain a table named gpkg_metadata. If present it SHALL be defined per clauses Metadata Table, Table 1, and gpkg_metadata Table Definition SQL."
Corrige: "A GeoPackage MAY contain a table named gpkg_metadata. If present it SHALL be defined per clauses Metadata Table, Table 1, and gpkg_metadata Table Definition SQL."