### PR TITLE
Update clause_4_terms_and_definitions.adoc

### DIFF
--- a/spec/crs_wkt/clause_4_terms_and_definitions.adoc
+++ b/spec/crs_wkt/clause_4_terms_and_definitions.adoc
@@ -9,11 +9,11 @@ coordinate epoch::
 A property of a dynamic coordinate reference system indicating the date at which the coordinates are valid. (SOURCE: OGC 18-005r4)
 
 Coordinate Reference System (CRS)::
-A coordinate reference system, or spatial reference system (SRS), is a set of mathematical rules for specifying how coordinates are to be assigned to points that is related to an object by a datum. (SOURCE: ISO 19111:2019) 
+A coordinate reference system, or spatial reference system (SRS), is a set of mathematical rules for specifying how coordinates are to be assigned to a point that is related to an object by a datum. (SOURCE: ISO 19111:2019) 
 
 [NOTE]
 ====
-The GeoPackage Encoding Standard (GES) uses the term "spatial reference system." In the GES, a spatial reference system is realized through a `gpkg_spatial_ref_sys` row.
+The GeoPackage Encoding Standard (GES) uses the term "spatial reference system." In the GES, a spatial reference system is realized through a row in the `gpkg_spatial_ref_sys` table.
 ====
 
 well-known text (WKT)::


### PR DESCRIPTION
Note:  In reviewing the extension, for Coordinate Reference System (CRS), the definition is not from OGC, but appears to be paraphrased from ISO 19111.   I just changed the plurality, and did not align with what I see in other definition--suggest changing to:

coordinate reference system (CRS)
coordinate system that is related to an object by a datum [ISO 19111:2019, definition 3.1.9]

coordinate system
set of mathematical rules for specifying how coordinates are to be assigned to points [ISO 19111:2019, definition 3.1.11]