### PR TITLE
Make DATETIME seconds optional and fractional seconds more flexible

### DIFF
--- a/spec/core/1_base.adoc
+++ b/spec/core/1_base.adoc
@@ -112,9 +112,14 @@ The columns of tables in a GeoPackage SHALL only be declared using one of the da
 |TEXT{(maxchar_count)}| Variable length string encoded in either UTF-8 or UTF-16, determined by PRAGMA encoding; see http://www.sqlite.org/pragma.html#pragma_encoding. The optional maxchar_count defines the maximum number of characters in the string. If not specified, the length is unbounded. The count is provided for informational purposes, and applications MAY choose to truncate longer strings if encountered. When present, it is best practice for applications to adhere to the character count. Stored as SQLite TEXT.
 |BLOB{(max_size)}     | Variable length binary data. The optional max_size defines the maximum number of bytes in the blob. If not specified, the length is unbounded. The size is provided for informational purposes. When present, it is best practice for applications adhere to the maximum blob size. Stored as SQLite BLOB.
 |<geometry_type_name> | Geometry encoded as per clause <<gpb_format>>. <geometry type_name> is one of the core geometry types listed in <<geometry_types>> encoded per clause 2.1.3 or a geometry type encoded per an extension such as <<extension_geometry_types>>. Geometry Types XY, XYZ, XYM and XYZM geometries use the same data type. Stored as SQLite BLOB.
-|DATE                 | ISO-8601 date string in the form YYYY-MM-DD encoded in either UTF-8 or UTF-16. See TEXT. Stored as SQLite TEXT.
-|DATETIME             | ISO-8601 date/time string in the form YYYY-MM-DDTHH:MM:SS.SSSZ with T separator character and Z suffix for coordinated universal time (UTC) encoded in either UTF-8 or UTF-16. See TEXT. Stored as SQLite TEXT.
+|DATE                 | http://www.iso.org/iso/catalogue_detail?csnumber=40874[ISO 8601] <<I29>> date string in the form YYYY-MM-DD encoded in either UTF-8 or UTF-16. See TEXT. Stored as SQLite TEXT (see TEXT above).
+|DATETIME             | ISO-8601 date/time string in the form YYYY-MM-DDTHH:MM[:SS.SSS]Z with T separator character, Z suffix for coordinated universal time (UTC), and encoded in either UTF-8 or UTF-16. Seconds and fractional seconds are OPTIONAL. Fractional seconds MAY have fewer or more than three digits. Stored as SQLite TEXT (see TEXT above).
 |=======================================================================
+
+[WARNING]
+====
+The SQLite https://sqlite.org/lang_datefunc.html[Date And Time Functions] internally store a timestamp in a way that makes the maximum precision 1 millisecond. Therefore, those functions are unsuitable for dealing with timestamps having a higher precision than one millisecond.
+====
 
 ====== File Integrity
 
@@ -280,7 +285,7 @@ The `last_change` SHOULD contain the timestamp of when the content in the refere
 [caption=""]
 .Requirement 15
 ====
-Values of the `gpkg_contents` table `last_change` column SHALL be in http://www.iso.org/iso/catalogue_detail?csnumber=40874[ISO 8601] <<I29>> format containing a complete date plus UTC hours, minutes, seconds and a decimal fraction of a second, with a 'Z' ('zulu') suffix indicating UTC. The ISO8601 format is as defined by the strftime function '%Y-%m-%dT%H:%M:%fZ' format string applied to the current time. ^<<K7>>^
+Values of the `gpkg_contents` table `last_change` column SHALL be in a DATETIME format as per <<r5>>.^<<K7>>^
 ====
 
 The bounding box (`min_x`, `min_y`, `max_x`, `max_y`) provides an informative bounding box of the content. Applications may use this bounding box as the extents of a default view but there are no requirements that this bounding box be exact or represent the minimum bounding box of the content. The values are in the units specified by that CRS.

--- a/spec/core/annexes/ats.adoc
+++ b/spec/core/annexes/ats.adoc
@@ -200,7 +200,7 @@
 [cols="1,5a"]
 |========================================
 |*Test Case ID* |+/base/core/contents/data/data_values_last_change+
-|*Test Purpose* |Verify that the `gpkg_contents` table `last_change` column values are in ISO 8601 [29]format containing a complete date plus UTC hours, minutes, seconds and a decimal fraction of a second, with a 'Z' ("zulu") suffix indicating UTC.
+|*Test Purpose* |Verify that the `gpkg_contents` table `last_change` column values are in ISO 8601 [29] format as per <<r5>>.
 |*Test Method* |
 . SELECT last_change from gpkg_contents.
 . Not testable if returns an empty result set.

--- a/spec/core/annexes/endnotes.adoc
+++ b/spec/core/annexes/endnotes.adoc
@@ -11,7 +11,7 @@
 - [[[K6]]] New applications should use the latest available SQLite version software <<I8>>
 - [[[K6a]]] The use of the AUTOINCREMENT keyword is optional but recommended. Implementers MAY omit the AUTOINCREMENT keyword for performance reasons, with the understanding that doing so has the potential to allow primary key identifiers to be reused.
 - [[[K6b]]] When a table has a primary key that is backed by a ROWID, the "null" flag is ignored.
-- [[[K7]]] The following statement selects an ISO 8601 timestamp value using the SQLite strftime function: SELECT (strftime('%Y-%m-%dT%H:%M:%fZ','now')).
+- [[[K7]]] The following statement selects an ISO 8601 timestamp value with millisecond precision using the SQLite strftime function: SELECT (strftime('%Y-%m-%dT%H:%M:%fZ','now')).
 - [[[K8]]] GeometryCollection is a generic term for the ST_GeomCollection type defined in <<I12>>, which uses it for the definition of Well Known Text (WKT) and Well Known Binary (WKB) encodings. The SQL type name GEOMETRYCOLLECTION defined in <<I10>> and used in Clause 1.1.2.1.1 and Annex G below refers to the SQL BLOB encoding of a GeometryCollection.
 - [[[K9]]] OGC WKB simple feature geometry types specified in <<I9>> are a subset of the ISO WKB geometry types specified in <<I12>>
 - [[[K10]]] WKB geometry types are are restricted to 0, 1 and 2-dimensional geometric objects that exist in 2, 3 or 4-dimensional coordinate space; they are not geographic or geodesic geometry types.
@@ -41,6 +41,6 @@
 - [[[K34]]] The "catalog" md_scope MAY be used for Feature Catalog (B40) information stored as XML metadata that is linked to features stored in a GeoPackage.
 - [[[K35]]] The "schema" md_scope MAY be used for Application Schema (B37)(B38)(B39)(B44) information stored as XML metadata that is linked to features stored in a GeoPackage.
 - [[[K36]]] The "taxonomy" md_scope MAY be used for taxonomy or knowledge system (B41)(B42) "linked data" information stored as XML metadata that is linked to features stored in a GeoPackage.
-- [[[K37]]] The following statement selects an ISO 8601timestamp value using the SQLite strftime function: SELECT (strftime('%Y-%m-%dT%H:%M:%fZ','now')).
+- [[[K37]]] The following statement selects an ISO 8601 timestamp value with millisecond precision using the SQLite strftime function: SELECT (strftime('%Y-%m-%dT%H:%M:%fZ','now')).
 - [[[K38]]] A GeoPackage is not required to contain a gpkg_data_columns table. The gpkg_data_columns table in a GeoPackage MAY be empty.
 - [[[K39]]] GeoPackages MAY contain MIME types other than the raster image types specified in clauses 2.2.4, 2.2.5, and 3.2.2 as feature attributes, but they are not required to do so.

--- a/spec/core/annexes/extension_metadata.adoc
+++ b/spec/core/annexes/extension_metadata.adoc
@@ -223,7 +223,7 @@ Every other `gpkg_metadata_reference` table row SHALL have a `row_id_value` colu
 [caption=""]
 .Requirement 100
 ====
-Every `gpkg_metadata_reference` table row timestamp column value SHALL be in ISO 8601 <<I29>> format containing a complete date plus UTC hours, minutes, seconds and a decimal fraction of a second, with a 'Z' ('zulu') suffix indicating UTC.^<<K37>>^
+Every `gpkg_metadata_reference` table row timestamp column value SHALL be in a DATETIME format as per <<r5>>.^<<K37>>^
 ====
 
 [[r101]]
@@ -398,7 +398,7 @@ Every `gpkg_metadata_reference` table row `md_parent_id` column value that is NO
 . SELECT timestamp from gpkg_metadata_reference.
 .  Not testable if returns an empty result set
 . For each row from step 1
-.. Fail if format of returned value does not match yyyy-mm-ddThh:mm:ss.hhhZ
+.. Fail if format of returned value does not match the format as per <<r5>>
 .. Log pass otherwise
 . Pass if logged pass and no fails.
 |*Reference* |Annex F.8 Req 100


### PR DESCRIPTION
Update the relevant end notes and tests.
Add warning regarding the use of the built-in date and time functions. This is a substantive change.

Closes #648

Encapsulates #649 and #651 