### PR TITLE
Patch R-tree index triggers

### DIFF
--- a/spec/core/annexes/extension_spatialindex.adoc
+++ b/spec/core/annexes/extension_spatialindex.adoc
@@ -160,7 +160,7 @@ END;
 
 /* Conditions: Update a non-empty geometry with another non-empty geometry
    Actions   : Replace record from R-tree for <i> */
-CREATE TRIGGER rtree_<t>_<c>_update6_old_geom_notnull AFTER UPDATE OF <c> ON <t>
+CREATE TRIGGER rtree_<t>_<c>_update6 AFTER UPDATE OF <c> ON <t>
   WHEN OLD.<i> = NEW.<i> AND
        (NEW.<c> NOTNULL AND NOT ST_IsEmpty(NEW.<c>)) AND
        (OLD.<c> NOTNULL AND NOT ST_IsEmpty(OLD.<c>))
@@ -175,7 +175,7 @@ END;
 
 /* Conditions: Update a null/empty geometry with a non-empty geometry
    Actions   : Insert record into R-tree for new <i> */
-CREATE TRIGGER rtree_<t>_<c>_update7_old_geom_null AFTER UPDATE OF <c> ON <t>
+CREATE TRIGGER rtree_<t>_<c>_update7 AFTER UPDATE OF <c> ON <t>
   WHEN OLD.<i> = NEW.<i> AND
        (NEW.<c> NOTNULL AND NOT ST_IsEmpty(NEW.<c>)) AND
        (OLD.<c> ISNULL OR ST_IsEmpty(OLD.<c>))

--- a/spec/core/release_notes/1.4.0/annex-history.adoc
+++ b/spec/core/release_notes/1.4.0/annex-history.adoc
@@ -7,6 +7,8 @@
 |Date |Release |Editor | Primary clauses modified |Descriptions
 |2023-03-19 |0.1 |J. Yutzler | all| Initial Revision
 |2023-03-29 |0.2 |J. Yutzler | 4, 6| 640/655
+|2023-05-24 |0.3 |J. Yutzler | 4, 6| 660/661
+|2023-05-31 |0.4 |J. Yutzler | 4  | OAB Review
 |====================
 
 For the complete revision history, see link:https://github.com/opengeospatial/geopackage/commits/master/spec/core/release_notes/1.4.0[the GitHub repository].

--- a/spec/core/release_notes/1.4.0/clause-4-change-log.adoc
+++ b/spec/core/release_notes/1.4.0/clause-4-change-log.adoc
@@ -60,6 +60,6 @@ See <<Clause_Critical>> for more information on critical changes and
 |[yellow-background]#link:https://github.com/opengeospatial/geopackage/pull/661[#661]#
 |[yellow-background]#S#
 |[yellow-background]#Annex F.3#
-|[yellow-background]#Deprecate update1 and update3 triggers, add update5, update6, and update7 triggers#
+|[yellow-background]#Replace update1 trigger with update6 and update7 to support upsert operations#
 |[yellow-background]#Correctness#
 |=======================================================================


### PR DESCRIPTION
Follow-up of https://github.com/opengeospatial/geopackage/pull/661 

Swallows https://github.com/opengeospatial/geopackage/pull/663

drop _old_geom_notnull suffix from _update6 trigger and _old_geom_null suffix from _update7 trigger

also: revising summary based on OAB feedback