### PR TITLE
Update EPSG reference B3

### DIFF
--- a/spec/core/1_base.adoc
+++ b/spec/core/1_base.adoc
@@ -225,7 +225,7 @@ Definition column WKT values in the `gpkg_spatial_ref_sys` table define the Spat
 [caption=""]
 .Requirement 11
 ====
-The `gpkg_spatial_ref_sys` table SHALL contain at a minimum the records listed in <<gpkg_spatial_ref_sys_records>>. The record with an `srs_id` of 4326 SHALL correspond to http://www.google.com/search?as_q=WGS-84[WGS-84] <<I15>> as defined by https://epsg.org/home.html[EPSG] in https://epsg.org/crs_4326/WGS-84.html[4326] <<I13>>. The record with an `srs_id` of -1 SHALL be used for undefined Cartesian coordinate reference systems. The record with an `srs_id` of 0 SHALL be used for undefined geographic coordinate reference systems.
+The `gpkg_spatial_ref_sys` table SHALL contain at a minimum the records listed in <<gpkg_spatial_ref_sys_records>>. The record with an `srs_id` of 4326 SHALL correspond to http://www.google.com/search?as_q=WGS-84[WGS-84] <<I15>> as defined by https://epsg.org/home.html[EPSG] <<B3>> in https://epsg.org/crs_4326/WGS-84.html[4326] <<I13>>. The record with an `srs_id` of -1 SHALL be used for undefined Cartesian coordinate reference systems. The record with an `srs_id` of 0 SHALL be used for undefined geographic coordinate reference systems.
 ====
 
 [#gpkg_spatial_ref_sys_records,reftext='{table-caption} {counter:table-num}']

--- a/spec/core/annexes/biblio.adoc
+++ b/spec/core/annexes/biblio.adoc
@@ -4,7 +4,7 @@
 [bibliography]
 - [[[B1]]] http://developer.android.com/guide/topics/data/data-storage.html#db
 - [[[B2]]] https://developer.apple.com/technologies/ios/data-management.html
-- [[[B3]]] (This document is no longer available)
+- [[[B3]]] International Association of Oil & Gas Producers (IOGP): Understanding the EPSG Geodetic Parameter Dataset. Report 373-07-1 (2022). https://epsg.org/guidance-notes.html
 - [[[B4]]] http://en.wikipedia.org/wiki/ASCII
 - [[[B5]]] http://www.sqlite.org/lang_createtable.html#rowid
 - [[[B6]]] ISO 19115-2 Geographic information - - Metadata - Part 2: Metadata for imagery and gridded data


### PR DESCRIPTION
The document previously available at [http://www.epsg.org/guides/docs/_**G7-1**_.pdf](http://www.epsg.org/guides/docs/G7-1.pdf) (see [c8f4642de502c2eff04a7aaed62d1c6faccdae2b](https://github.com/opengeospatial/geopackage/commit/c8f4642de502c2eff04a7aaed62d1c6faccdae2b#diff-0283a391ff59b99966df611614eee90152b8e5c474bc24d9d41b967929ec5fd9) and #670) is available via https://epsg.org/guidance-notes.html

![image](https://github.com/opengeospatial/geopackage/assets/11427611/fc086749-1ee3-4b0e-b929-68fe8b5d02ce)

The direct link is https://drive.tiny.cloud/1/4m326iu12oa8re9cjiadxonharclteqb4mumfxj71zsttwkx/07cead43-4462-436c-8636-5da9531eebfd, but https://epsg.org/guidance-notes.html is a more persistent link, therefore the proposal to use the latter link in the bibliography.